### PR TITLE
Step1(질문 삭제하기 기능 리팩토링)

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -74,13 +74,7 @@ public class Answer extends AbstractEntity {
         return "Answer [id=" + getId() + ", writer=" + writer + ", contents=" + contents + "]";
     }
 
-    public Answer delete(User loginUser) throws CannotDeleteException {
-        if (!isOwner(loginUser)) {
-            throw new CannotDeleteException("다른 사람이 쓴 답변이여서 삭제할 수 없습니다.");
-        }
-
-        this.deleted = true;
-
-        return this;
+    public Answer delete() {
+        return setDeleted(true);
     }
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -71,5 +72,15 @@ public class Answer extends AbstractEntity {
     @Override
     public String toString() {
         return "Answer [id=" + getId() + ", writer=" + writer + ", contents=" + contents + "]";
+    }
+
+    public Answer delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이여서 삭제할 수 없습니다.");
+        }
+
+        this.deleted = true;
+
+        return this;
     }
 }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,35 @@
+package qna.domain;
+
+import qna.CannotDeleteException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class Answers {
+    private final List<Answer> answers;
+
+    public Answers(final List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public List<DeleteHistory> deleteAll(User loginUser) throws CannotDeleteException {
+        validateAnswersOwner(loginUser);
+
+        return answers.stream()
+                .map(Answer::delete)
+                .map(deleted -> new DeleteHistory(ContentType.ANSWER, deleted.getId(), loginUser, LocalDateTime.now()))
+                .collect(Collectors.toList());
+    }
+
+    private void validateAnswersOwner(User loginUser) throws CannotDeleteException {
+        Optional<Answer> findAnswer = answers.stream()
+                .filter(answer -> !answer.isOwner(loginUser))
+                .findAny();
+
+        if (findAnswer.isPresent()) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 존재해서 삭제할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -103,7 +103,7 @@ public class Question extends AbstractEntity {
         Answers answers = new Answers(getAnswers());
         List<DeleteHistory> deleteHistories = answers.deleteAll(loginUser);
 
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), loginUser, LocalDateTime.now()));
+        deleteHistories.add(0, new DeleteHistory(ContentType.QUESTION, getId(), loginUser, LocalDateTime.now()));
         setDeleted(true);
 
         return deleteHistories;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,8 +1,10 @@
 package qna.domain;
 
 import org.hibernate.annotations.Where;
+import qna.CannotDeleteException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -91,5 +93,19 @@ public class Question extends AbstractEntity {
     @Override
     public String toString() {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";
+    }
+
+    public List<DeleteHistory> delete(final User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        Answers answers = new Answers(getAnswers());
+        List<DeleteHistory> deleteHistories = answers.deleteAll(loginUser);
+
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), loginUser, LocalDateTime.now()));
+        setDeleted(true);
+
+        return deleteHistories;
     }
 }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -35,24 +35,9 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,36 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @DisplayName("삭제하려는 답변작성자가 인자로받은 작성자와 다르면 CannotDeleteException throw")
+    @Test
+    void deleteAnswerFail() {
+        User loginUser = UserTest.SANJIGI;
+        assertThatThrownBy(() -> A1.delete(loginUser))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이여서 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("답변 삭제에 성공하면 deleted를 true 바꾸고 해당 답변을 반환한다.")
+    @Test
+    void deleteAnswerSuccess() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+
+        Answer deletedAnswer = A1.delete(loginUser);
+
+        assertAll(
+                () -> assertThat(deletedAnswer).isEqualTo(A1),
+                () -> assertThat(deletedAnswer.isDeleted()).isTrue()
+        );
+    }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -12,21 +12,10 @@ public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
 
-    @DisplayName("삭제하려는 답변작성자가 인자로받은 작성자와 다르면 CannotDeleteException throw")
+    @DisplayName("답변을 삭제하고 해당 답변을 반환한다.")
     @Test
-    void deleteAnswerFail() {
-        User loginUser = UserTest.SANJIGI;
-        assertThatThrownBy(() -> A1.delete(loginUser))
-                .isInstanceOf(CannotDeleteException.class)
-                .hasMessage("다른 사람이 쓴 답변이여서 삭제할 수 없습니다.");
-    }
-
-    @DisplayName("답변 삭제에 성공하면 deleted를 true 바꾸고 해당 답변을 반환한다.")
-    @Test
-    void deleteAnswerSuccess() throws CannotDeleteException {
-        User loginUser = UserTest.JAVAJIGI;
-
-        Answer deletedAnswer = A1.delete(loginUser);
+    void deleteAnswerSuccess() {
+        Answer deletedAnswer = A1.delete();
 
         assertAll(
                 () -> assertThat(deletedAnswer).isEqualTo(A1),

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,48 @@
+package qna.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnswersTest {
+
+    private List<Answer> answers;
+
+    @BeforeEach
+    void setUp() {
+        answers = new ArrayList<>();
+
+        answers.add(new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1"));
+        answers.add(new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents2"));
+        answers.add(new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents3"));
+    }
+
+    @DisplayName("전체 Answer를 제거하고 DeleteHistory 리스트를 반환한다.")
+    @Test
+    void deleteAll() throws CannotDeleteException {
+        Answers q1Answers = new Answers(answers);
+
+        List<DeleteHistory> deleteAnswerHistories = q1Answers.deleteAll(UserTest.JAVAJIGI);
+
+        assertThat(deleteAnswerHistories.size()).isEqualTo(answers.size());
+    }
+
+    @DisplayName("전체 Answer를 지울때 다른 사람이 쓴 답변이 하나라도 존재하면 CannotDeleteException throw")
+    @Test
+    void deleteAllThrowException() {
+        answers.add(new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents4"));
+        Answers q1Answers = new Answers(answers);
+
+        assertThatThrownBy(() -> q1Answers.deleteAll(UserTest.JAVAJIGI))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 존재해서 삭제할 수 없습니다.");
+    }
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,33 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("삭제에 성공하면 답변 삭제 히스토리를 포함한 질문 히스토리 리스트를 반환한다.")
+    @Test
+    void deleteQuestion() throws CannotDeleteException {
+        Q1.addAnswer(AnswerTest.A1);
+        List<DeleteHistory> deleteHistories = Q1.delete(UserTest.JAVAJIGI);
+
+        assertThat(deleteHistories.size()).isEqualTo(2);
+    }
+
+    @DisplayName("본인의 질문이 아니면 CannotDeleteException Throw")
+    @Test
+    void deleteQuestionThrowException() {
+        assertThatThrownBy(() -> Q1.delete(UserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("질문을 삭제할 권한이 없습니다.");
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -14,11 +14,18 @@ public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
 
+    private Question question;
+
+    @BeforeEach
+    void setUp() {
+        question = new Question("title", "contents").writeBy(UserTest.JAVAJIGI);
+    }
+
     @DisplayName("삭제에 성공하면 답변 삭제 히스토리를 포함한 질문 히스토리 리스트를 반환한다.")
     @Test
     void deleteQuestion() throws CannotDeleteException {
-        Q1.addAnswer(AnswerTest.A1);
-        List<DeleteHistory> deleteHistories = Q1.delete(UserTest.JAVAJIGI);
+        question.addAnswer(new Answer(UserTest.JAVAJIGI, question, "Answers Contents1"));
+        List<DeleteHistory> deleteHistories = question.delete(UserTest.JAVAJIGI);
 
         assertThat(deleteHistories.size()).isEqualTo(2);
     }
@@ -29,5 +36,14 @@ public class QuestionTest {
         assertThatThrownBy(() -> Q1.delete(UserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class)
                 .hasMessage("질문을 삭제할 권한이 없습니다.");
+    }
+
+    @DisplayName("답변중 본인의 답변이 아닌게 존재하면 CannotDeleteException Throw")
+    @Test
+    void deleteAnswerThrowException() {
+        question.addAnswer(new Answer(UserTest.SANJIGI, question, "Answers Contents2"));
+        assertThatThrownBy(() -> question.delete(UserTest.JAVAJIGI))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 존재해서 삭제할 수 없습니다.");
     }
 }


### PR DESCRIPTION
안녕하세요! 마지막 볼링 점수판 미션 시작하게된 이민형입니다!

Step1 - 질문 삭제하기 기능 리팩토링 진행하였습니다.
기존 QnaService의 질문 삭제 메소드에서 여러 로직들을 처리하던것을 Question 엔티티와 Answer 엔티티에서 처리하도록 변경하였는데
QnaService의 질문 삭제 테스트 코드에서도 각 경우에 대한 테스트도 진행해야한다고 생각하여 QnaService의 질문 삭제 기능 테스트 메소드들은 건드리지 않았습니다. 제가 옳게 판단하였는지 궁금합니다!

감사합니다.