### PR TITLE
Step1 - 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -70,6 +70,14 @@ public class Answer extends AbstractEntity {
         return writer;
     }
 
+    public Question getQuestion() {
+        return question;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
     @Override
     public String toString() {
         return "Answer [id=" + getId() + ", writer=" + writer + ", contents=" + contents + "]";

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -56,12 +56,12 @@ public class Answer extends AbstractEntity {
         return this.writer.equals(writer);
     }
 
-    public User getWriter() {
-        return writer;
+    public boolean isNotOwner(User writer) {
+        return !isOwner(writer);
     }
 
-    public String getContents() {
-        return contents;
+    public User getWriter() {
+        return writer;
     }
 
     public void toQuestion(Question question) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -18,10 +18,7 @@ public class Answer extends AbstractEntity {
     @Lob
     private String contents;
 
-    private boolean deleted = false;
-
-    public Answer() {
-    }
+    private boolean deleted;
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -43,13 +40,12 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
+    }
+
+    public void deleteAnswer() {
+        this.deleted = true;
     }
 
     public boolean isOwner(User writer) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -3,7 +3,12 @@ package qna.domain;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -27,11 +32,11 @@ public class Answer extends AbstractEntity {
     public Answer(Long id, User writer, Question question, String contents) {
         super(id);
 
-        if(writer == null) {
+        if (writer == null) {
             throw new UnAuthorizedException();
         }
 
-        if(question == null) {
+        if (question == null) {
             throw new NotFoundException();
         }
 
@@ -44,8 +49,9 @@ public class Answer extends AbstractEntity {
         return deleted;
     }
 
-    public void deleteAnswer() {
+    public DeleteHistory deleteAnswer() {
         this.deleted = true;
+        return DeleteHistory.of(ContentType.ANSWER, this.getId(), this.writer, LocalDateTime.now());
     }
 
     public boolean isOwner(User writer) {
@@ -56,12 +62,12 @@ public class Answer extends AbstractEntity {
         return !isOwner(writer);
     }
 
-    public User getWriter() {
-        return writer;
-    }
-
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public User getWriter() {
+        return writer;
     }
 
     @Override

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,12 +7,8 @@ public class Answers {
 
     private List<Answer> answers;
 
-    private Answers() {
+    public Answers() {
         this.answers = new ArrayList<>();
-    }
-
-    public static Answers of() {
-        return new Answers();
     }
 
     public void addToAnswer(Answer answer) {
@@ -21,26 +16,15 @@ public class Answers {
     }
 
     public boolean hasOtherOwnerAnswers(User user) {
-        for (Answer answer : this.answers) {
-            if (answer.isNotOwner(user)) {
-                return true;
-            }
-        }
-        return false;
+        return this.answers.stream().anyMatch(answer -> answer.isNotOwner(user));
     }
 
-    public List<DeleteHistory> generateDeleteHistories() {
+    public DeleteHistories deleteAnswers() {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : this.answers) {
-            DeleteHistory deleteHistory = DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
+            DeleteHistory deleteHistory = answer.deleteAnswer();
             deleteHistories.add(deleteHistory);
         }
-        return deleteHistories;
-    }
-
-    public void deleteAnswers() {
-        for (Answer answer : this.answers) {
-            answer.deleteAnswer();
-        }
+        return DeleteHistories.of(deleteHistories);
     }
 }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,40 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Answers {
+
+    private List<Answer> answers;
+
+    private Answers() {
+        this.answers = new ArrayList<>();
+    }
+
+    public static Answers of() {
+        return new Answers();
+    }
+
+    public void addToAnswer(Answer answer) {
+        this.answers.add(answer);
+    }
+
+    public boolean hasOtherOwnerAnswers(User user) {
+        for (Answer answer : this.answers) {
+            if (answer.isNotOwner(user)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<DeleteHistory> generateDeleteHistories() {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : this.answers) {
+            DeleteHistory deleteHistory = DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
+            deleteHistories.add(deleteHistory);
+        }
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -37,4 +37,10 @@ public class Answers {
         }
         return deleteHistories;
     }
+
+    public void deleteAnswers() {
+        for (Answer answer : this.answers) {
+            answer.deleteAnswer();
+        }
+    }
 }

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,4 +1,34 @@
 package qna.domain;
 
-public class DeleteHistorys {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DeleteHistories {
+
+    private List<DeleteHistory> deleteHistories;
+
+    private DeleteHistories() {
+        this.deleteHistories = new ArrayList<>();
+    }
+
+    public static DeleteHistories of() {
+        return new DeleteHistories();
+    }
+
+    public void addToDeleteHistories(Question question) {
+        DeleteHistory questionHistory = question.generateDeleteHistoryForQuestion();
+        this.deleteHistories.add(questionHistory);
+
+        addToDeleteHistoriesForAnswers(question.getAnswers());
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return Collections.unmodifiableList(this.deleteHistories);
+    }
+
+    private void addToDeleteHistoriesForAnswers(Answers answers) {
+        List<DeleteHistory> deleteHistories = answers.generateDeleteHistories();
+        this.deleteHistories.addAll(deleteHistories);
+    }
 }

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,4 @@
+package qna.domain;
+
+public class DeleteHistorys {
+}

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,7 +1,8 @@
 package qna.domain;
 
+import qna.util.CollectionUtils;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -9,28 +10,22 @@ public class DeleteHistories {
 
     private List<DeleteHistory> deleteHistories;
 
-    private DeleteHistories() {
-        this.deleteHistories = new ArrayList<>();
+    private DeleteHistories(List<DeleteHistory> deleteHistories) {
+        if (CollectionUtils.isEmpty(deleteHistories)) {
+            this.deleteHistories = new ArrayList<>();
+        }
+
+        this.deleteHistories = new ArrayList<>(deleteHistories);
     }
 
-    public static DeleteHistories of() {
-        return new DeleteHistories();
+    public static DeleteHistories of(List<DeleteHistory> deleteHistories) {
+        return new DeleteHistories(deleteHistories);
     }
 
-    public void addToDeleteHistories(Question question) {
-        DeleteHistory questionHistory = question.generateDeleteHistoryForQuestion();
-        this.deleteHistories.add(questionHistory);
-
-        addToDeleteHistoriesForAnswers(question.getAnswers());
-    }
-
-    public List<DeleteHistory> getDeleteHistories() {
-        return Collections.unmodifiableList(this.deleteHistories);
-    }
-
-    private void addToDeleteHistoriesForAnswers(Answers answers) {
-        List<DeleteHistory> deleteHistories = answers.generateDeleteHistories();
-        this.deleteHistories.addAll(deleteHistories);
+    public static DeleteHistories mergeHistories(DeleteHistory targetHistory, DeleteHistories targetHistories) {
+        List<DeleteHistory> mergedHistories = new ArrayList<>(targetHistories.deleteHistories);
+        mergedHistories.add(targetHistory);
+        return DeleteHistories.of(mergedHistories);
     }
 
     @Override
@@ -44,7 +39,7 @@ public class DeleteHistories {
         }
 
         DeleteHistories that = (DeleteHistories) o;
-        return Objects.equals(this.deleteHistories, that.deleteHistories);
+        return this.deleteHistories.containsAll(that.deleteHistories);
     }
 
     @Override

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -3,6 +3,7 @@ package qna.domain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class DeleteHistories {
 
@@ -30,5 +31,24 @@ public class DeleteHistories {
     private void addToDeleteHistoriesForAnswers(Answers answers) {
         List<DeleteHistory> deleteHistories = answers.generateDeleteHistories();
         this.deleteHistories.addAll(deleteHistories);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DeleteHistories that = (DeleteHistories) o;
+        return Objects.equals(this.deleteHistories, that.deleteHistories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.deleteHistories);
     }
 }

--- a/src/main/java/qna/domain/DeleteHistoriesRepository.java
+++ b/src/main/java/qna/domain/DeleteHistoriesRepository.java
@@ -1,0 +1,7 @@
+package qna.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface DeleteHistoriesRepository extends CrudRepository<DeleteHistories, Long> {
+
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -19,16 +19,17 @@ public class DeleteHistory {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_deletehistory_to_user"))
     private User deletedBy;
 
-    private LocalDateTime createDate = LocalDateTime.now();
+    private LocalDateTime createDate;
 
-    public DeleteHistory() {
-    }
-
-    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
+    private DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
         this.deletedBy = deletedBy;
         this.createDate = createDate;
+    }
+
+    public static DeleteHistory of(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
+        return new DeleteHistory(contentType, contentId, deletedBy, createDate);
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -73,6 +73,7 @@ public class Question extends AbstractEntity {
 
     public void deleteQuestion() {
         this.deleted = true;
+        this.answers.deleteAnswers();
     }
 
     public Answers getAnswers() {

--- a/src/main/java/qna/service/DeleteHistoryService.java
+++ b/src/main/java/qna/service/DeleteHistoryService.java
@@ -3,6 +3,7 @@ package qna.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import qna.domain.DeleteHistories;
 import qna.domain.DeleteHistory;
 import qna.domain.DeleteHistoryRepository;
 
@@ -20,7 +21,7 @@ public class DeleteHistoryService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void save(DeleteHistory deleteHistory) {
-        deleteHistoryRepository.save(deleteHistory);
+    public void saveAll(DeleteHistories deleteHistories) {
+        this.saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/main/java/qna/service/DeleteHistoryService.java
+++ b/src/main/java/qna/service/DeleteHistoryService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import qna.domain.DeleteHistories;
+import qna.domain.DeleteHistoriesRepository;
 import qna.domain.DeleteHistory;
 import qna.domain.DeleteHistoryRepository;
 
@@ -15,13 +16,16 @@ public class DeleteHistoryService {
     @Resource(name = "deleteHistoryRepository")
     private DeleteHistoryRepository deleteHistoryRepository;
 
+    @Resource(name = "deleteHistoriesRepository")
+    private DeleteHistoriesRepository deleteHistoriesRepository;
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveAll(List<DeleteHistory> deleteHistories) {
         deleteHistoryRepository.saveAll(deleteHistories);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveAll(DeleteHistories deleteHistories) {
-        this.saveAll(deleteHistories.getDeleteHistories());
+    public void save(DeleteHistories deleteHistories) {
+        deleteHistoriesRepository.save(deleteHistories);
     }
 }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -40,17 +40,7 @@ public class QnAService {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        if (question.hasQuestionOtherOwnerAnswers(loginUser)) {
-            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-        }
-
-        question.deleteQuestion();
-        saveDeleteHistories(question);
-    }
-
-    private void saveDeleteHistories(Question question) {
-        DeleteHistories deleteHistories = DeleteHistories.of();
-        deleteHistories.addToDeleteHistories(question);
-        deleteHistoryService.saveAll(deleteHistories); // 테스트하기 어려움
+        DeleteHistories deleteHistories = question.deleteQuestion();
+        deleteHistoryService.save(deleteHistories);
     }
 }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -6,12 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.*;
+import qna.domain.AnswerRepository;
+import qna.domain.DeleteHistories;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
 
 import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service("qnaService")
 public class QnAService {
@@ -34,25 +35,22 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
-        Question question = findQuestionById(questionId);
+        Question question = findQuestionById(questionId); // 테스트하기 어려움
         if (!question.isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
+        if (question.hasQuestionOtherOwnerAnswers(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        question.deleteQuestion();
+        saveDeleteHistories(question);
+    }
+
+    private void saveDeleteHistories(Question question) {
+        DeleteHistories deleteHistories = DeleteHistories.of();
+        deleteHistories.addToDeleteHistories(question);
+        deleteHistoryService.saveAll(deleteHistories); // 테스트하기 어려움
     }
 }

--- a/src/main/java/qna/util/CollectionUtils.java
+++ b/src/main/java/qna/util/CollectionUtils.java
@@ -1,0 +1,4 @@
+package qna.util;
+
+public class CollectionUtils {
+}

--- a/src/main/java/qna/util/CollectionUtils.java
+++ b/src/main/java/qna/util/CollectionUtils.java
@@ -1,4 +1,10 @@
 package qna.util;
 
+import java.util.Collection;
+
 public class CollectionUtils {
+
+    public static boolean isEmpty(final Collection<?> coll) {
+        return coll == null || coll.isEmpty();
+    }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,84 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import qna.NotFoundException;
+import qna.UnAuthorizedException;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 public class AnswerTest {
+
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @DisplayName("Answer 생성자 테스트")
+    @ParameterizedTest
+    @MethodSource("provideAnswer")
+    void answerConstructorTest(final long id, final User user, final Question question, final String content) {
+        Answer answer = new Answer(id, user, question, content);
+
+        assertThat(answer.getWriter()).isEqualTo(user);
+        assertThat(answer.getQuestion()).isEqualTo(question);
+        assertThat(answer.getContents()).isEqualTo(content);
+    }
+
+    private static Stream<Arguments> provideAnswer() {
+        return Stream.of(
+                Arguments.of(1L, UserTest.JAVAJIGI, QuestionTest.Q1, "abc"),
+                Arguments.of(2L, UserTest.SANJIGI, QuestionTest.Q2, "efg")
+        );
+    }
+
+    @DisplayName("Answer 생성자 예외 테스트 :: UnAuthorizedException")
+    @ParameterizedTest
+    @MethodSource("provideUnAuthorizedExceptionAnswer")
+    void answerConstructorUnAuthorizedExceptionTest(final long id, final User user, final Question question, final String content) {
+        assertThatExceptionOfType(UnAuthorizedException.class)
+                .isThrownBy(() -> new Answer(id, user, question, content));
+    }
+
+    private static Stream<Arguments> provideUnAuthorizedExceptionAnswer() {
+        return Stream.of(
+                Arguments.of(1L, null, QuestionTest.Q1, "abc")
+        );
+    }
+
+    @DisplayName("Answer 생성자 예외 테스트 :: NotFoundException")
+    @ParameterizedTest
+    @MethodSource("provideNotFoundExceptionAnswer")
+    void answerConstructorNotFoundExceptionTest(final long id, final User user, final Question question, final String content) {
+        assertThatExceptionOfType(NotFoundException.class)
+                .isThrownBy(() -> new Answer(id, user, question, content));
+    }
+
+    private static Stream<Arguments> provideNotFoundExceptionAnswer() {
+        return Stream.of(
+                Arguments.of(1L, UserTest.SANJIGI, null, "abc")
+        );
+    }
+
+    @DisplayName("Answer deleteAnswer() 메소드 테스트")
+    @ParameterizedTest
+    @MethodSource("provideAnswerForDelete")
+    void deleteAnswerTest(final long id, final User user, final Question question, final String content, final DeleteHistory expected) {
+        Answer answer = new Answer(id, user, question, content);
+        DeleteHistory deleteHistory = answer.deleteAnswer();
+
+        assertThat(answer.isDeleted()).isTrue();
+        assertThat(deleteHistory).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideAnswerForDelete() {
+        return Stream.of(
+                Arguments.of(1L, UserTest.JAVAJIGI, QuestionTest.Q1, "abc", DeleteHistory.of(ContentType.ANSWER, 1L, UserTest.JAVAJIGI, LocalDateTime.now())),
+                Arguments.of(2L, UserTest.SANJIGI, QuestionTest.Q2, "efg", DeleteHistory.of(ContentType.ANSWER, 2L, UserTest.SANJIGI, LocalDateTime.now()))
+        );
+    }
 }

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,4 @@
+package qna.domain;
+
+public class AnswersTest {
+}

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,4 +1,55 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class AnswersTest {
+
+    @DisplayName("Answers deleteAnswers() 메소드 테스트")
+    @ParameterizedTest
+    @MethodSource("provideAnswersForDelete")
+    void deleteAnswersTest(final Answer answer, final DeleteHistories expected) {
+
+        Answers answers = new Answers();
+        answers.addToAnswer(answer);
+
+        DeleteHistories deleteHistories = answers.deleteAnswers();
+        assertThat(deleteHistories).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideAnswersForDelete() {
+        return Stream.of(
+                Arguments.of(
+                        AnswerTest.A1,
+                        DeleteHistories.of(Collections.singletonList(DeleteHistory.of(ContentType.ANSWER, null, UserTest.JAVAJIGI, LocalDateTime.now())))
+                )
+        );
+    }
+
+    @DisplayName("Answers hasOtherOwnerAnswersTest() 메소드 테스트")
+    @ParameterizedTest
+    @MethodSource("provideAnswersForHasOtherOwnerAnswersTest")
+    void hasOtherOwnerAnswersTest(final Answer answer, final User user, final boolean expected) {
+
+        Answers answers = new Answers();
+        answers.addToAnswer(answer);
+
+        boolean result = answers.hasOtherOwnerAnswers(user);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideAnswersForHasOtherOwnerAnswersTest() {
+        return Stream.of(
+                Arguments.of(AnswerTest.A1, UserTest.JAVAJIGI, false),
+                Arguments.of(AnswerTest.A2, UserTest.JAVAJIGI, true)
+        );
+    }
 }

--- a/src/test/java/qna/domain/DeleteHistoriesTest.java
+++ b/src/test/java/qna/domain/DeleteHistoriesTest.java
@@ -1,4 +1,8 @@
 package qna.domain;
 
+import java.util.Arrays;
+
 public class DeleteHistoriesTest {
+
+    public static final DeleteHistories HISTORIES = DeleteHistories.of(Arrays.asList(DeleteHistoryTest.D1_Q, DeleteHistoryTest.D2_A));
 }

--- a/src/test/java/qna/domain/DeleteHistoriesTest.java
+++ b/src/test/java/qna/domain/DeleteHistoriesTest.java
@@ -1,0 +1,4 @@
+package qna.domain;
+
+public class DeleteHistoriesTest {
+}

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,10 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+
+public class DeleteHistoryTest {
+
+    public static final DeleteHistory D1_Q = DeleteHistory.of(ContentType.QUESTION, 1L, UserTest.SANJIGI, LocalDateTime.now());
+    public static final DeleteHistory D2_A = DeleteHistory.of(ContentType.ANSWER, 2L, UserTest.JAVAJIGI, LocalDateTime.now());
+
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,57 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import qna.CannotDeleteException;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("Question deleteQuestionTest() 메소드 테스트")
+    @ParameterizedTest
+    @MethodSource("provideQuestion")
+    void deleteQuestionTest(final Answer answer, final DeleteHistories expected) throws Exception {
+        Q1.addAnswer(answer);
+        DeleteHistories deleteHistories = Q1.deleteQuestion();
+        assertThat(deleteHistories).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideQuestion() {
+        return Stream.of(
+                Arguments.of(AnswerTest.A1, DeleteHistories.of(Arrays.asList(deleteHistory1(), deleteHistory2())))
+        );
+    }
+
+    private static DeleteHistory deleteHistory1() {
+        return DeleteHistory.of(ContentType.QUESTION, null, UserTest.JAVAJIGI, LocalDateTime.now());
+    }
+
+    private static DeleteHistory deleteHistory2() {
+        return DeleteHistory.of(ContentType.ANSWER, null, UserTest.JAVAJIGI, LocalDateTime.now());
+    }
+
+    @DisplayName("Question deleteQuestionTest() 메소드 예외 테스트 :: CannotDeleteException")
+    @ParameterizedTest
+    @MethodSource("provideCannotDeleteExceptionQuestion")
+    void deleteQuestionCannotDeleteExceptionTest(final Answer answer) {
+        Q1.addAnswer(answer);
+        assertThatExceptionOfType(CannotDeleteException.class)
+                .isThrownBy(Q1::deleteQuestion);
+    }
+
+    private static Stream<Arguments> provideCannotDeleteExceptionQuestion() {
+        return Stream.of(
+                Arguments.of(AnswerTest.A2)
+        );
+    }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -7,7 +7,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import qna.CannotDeleteException;
-import qna.domain.*;
+import qna.domain.Answer;
+import qna.domain.ContentType;
+import qna.domain.DeleteHistory;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.QuestionTest;
+import qna.domain.UserTest;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -34,7 +40,7 @@ public class QnaServiceTest {
     private Answer answer;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
         answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
         question.addAnswer(answer);
@@ -52,7 +58,7 @@ public class QnaServiceTest {
     }
 
     @Test
-    public void delete_다른_사람이_쓴_글() throws Exception {
+    public void delete_다른_사람이_쓴_글() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
@@ -72,7 +78,7 @@ public class QnaServiceTest {
     }
 
     @Test
-    public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
+    public void delete_답변_중_다른_사람이_쓴_글() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
@@ -82,8 +88,8 @@ public class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+                DeleteHistory.of(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         verify(deleteHistoryService).saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import qna.CannotDeleteException;
 import qna.domain.Answer;
 import qna.domain.ContentType;
+import qna.domain.DeleteHistories;
 import qna.domain.DeleteHistory;
 import qna.domain.Question;
 import qna.domain.QuestionRepository;
@@ -87,9 +88,8 @@ public class QnaServiceTest {
     }
 
     private void verifyDeleteHistories() {
-        List<DeleteHistory> deleteHistories = Arrays.asList(
-                DeleteHistory.of(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        DeleteHistories deleteHistories = DeleteHistories.of();
+        deleteHistories.addToDeleteHistories(question);
         verify(deleteHistoryService).saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -88,8 +88,11 @@ public class QnaServiceTest {
     }
 
     private void verifyDeleteHistories() {
-        DeleteHistories deleteHistories = DeleteHistories.of();
-        deleteHistories.addToDeleteHistories(question);
-        verify(deleteHistoryService).saveAll(deleteHistories);
+        List<DeleteHistory> dummy = Arrays.asList(
+                DeleteHistory.of(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+
+        DeleteHistories deleteHistories = DeleteHistories.of(dummy);
+        verify(deleteHistoryService).save(deleteHistories);
     }
 }


### PR DESCRIPTION
안녕하세요? ㅎㅎ 
최대한 상태를 꺼내지 말고 메시지를 보낸다라는 것에 초점을 둬서 개발을 진행했습니다.
하지만 getter를 쓸 수 밖에 없는 구간들이 몇 가지 있었는데, 도무지 어떻게 개선을 해야할지 모르겠습니다 ㅜㅜ

- Getter 를 쓴 부분
  - `DeleteHistoryService` 클래스에 `saveAll()` 메소드
    - DAO 관련 로직을 `DeleteHistories` 클래스에 넣을 수도 없어서 곤란했습니다.
  - `Answers` 클래스에 `generateDeleteHistories()` 메소드
    - `Answer` 에 대한 `DeleteHistory` 객체를 만들기 위해서는 `Answers` 클래스에 있는 `List<Answer>` 를 통해서 만들 수 밖에 없는 상황입니다.
    - 그런데 여기서 `DeleteHistory` 객체를 만들려면 `Answer` 클래스에서 정보를 꺼낼 수 밖에 없었습니다.
    - getter를 안쓰기 위한 더 좋은 방법은 없을까요?

혹시 개선 사항이나 더 필요한 부분이 있으면 언제든 리뷰 부탁드립니다.
감사합니다.