### PR TITLE
Step1 - 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,9 +1,10 @@
 package qna.domain;
 
-import qna.NotFoundException;
-import qna.UnAuthorizedException;
+import qna.exceptions.NotFoundException;
+import qna.exceptions.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -43,9 +44,33 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
+    public DeleteHistory delete() {
+        deleteAnswer();
+        return makeDeleteHistory();
+    }
+
     public Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;
+    }
+
+    public Answer deleteAnswer() {
+        this.deleted = true;
+        return this;
+    }
+
+    public Answer resurrectionAnswer() {
+        this.deleted = false;
+        return this;
+    }
+
+    public DeleteHistory makeDeleteHistory() {
+        return DeleteHistory.Builder()
+                .contentId(super.getId())
+                .contentType(ContentType.ANSWER)
+                .deletedBy(writer)
+                .createDate(LocalDateTime.now())
+                .build();
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,27 @@
+package qna.domain;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Answers {
+    private final List<Answer> answers;
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public static Answers from(List<Answer> answers) {
+        return new Answers(answers);
+    }
+
+    public List<DeleteHistory> deleteAll() {
+        return answers.stream()
+                .map(Answer::delete)
+                .collect(Collectors.toList());
+    }
+
+    public List<Answer> getAnswers() {
+        return Collections.unmodifiableList(answers);
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,24 @@
+package qna.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeleteHistories {
+    private List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public static DeleteHistories of(DeleteHistory history, List<DeleteHistory> histories) {
+        List<DeleteHistory> list = new ArrayList<>();
+        list.add(history);
+        list.addAll(histories);
+
+        return new DeleteHistories(list);
+    }
+
+    public List<DeleteHistory> getAll() {
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -21,14 +21,49 @@ public class DeleteHistory {
 
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory() {
+    public DeleteHistory() { }
+
+    public DeleteHistory(Builder builder) {
+        this.contentType = builder.contentType;
+        this.contentId = builder.contentId;
+        this.deletedBy = builder.deletedBy;
+        this.createDate = builder.createDate;
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
-        this.contentType = contentType;
-        this.contentId = contentId;
-        this.deletedBy = deletedBy;
-        this.createDate = createDate;
+    public static Builder Builder() {
+        return new Builder();
+    }
+
+    public static class Builder{
+        private ContentType contentType;
+        private Long contentId;
+        private User deletedBy;
+        private LocalDateTime createDate;
+
+        public Builder() { }
+
+        public Builder contentType(ContentType contentType){
+            this.contentType = contentType;
+            return this;
+        }
+        public Builder contentId(Long contentId){
+            this.contentId = contentId;
+            return this;
+        }
+        public Builder deletedBy(User deletedBy){
+            this.deletedBy = deletedBy;
+            return this;
+        }
+        public Builder createDate(LocalDateTime createDate){
+            this.createDate = createDate;
+            return this;
+        }
+
+        public DeleteHistory build() {
+            return new DeleteHistory(this);
+        }
+
+
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,6 +1,6 @@
 package qna.domain;
 
-import qna.UnAuthorizedException;
+import qna.exceptions.UnAuthorizedException;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/qna/exceptions/CannotDeleteException.java
+++ b/src/main/java/qna/exceptions/CannotDeleteException.java
@@ -1,4 +1,4 @@
-package qna;
+package qna.exceptions;
 
 public class CannotDeleteException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/qna/exceptions/ForbiddenException.java
+++ b/src/main/java/qna/exceptions/ForbiddenException.java
@@ -1,4 +1,4 @@
-package qna;
+package qna.exceptions;
 
 public class ForbiddenException extends RuntimeException{
     public ForbiddenException() {

--- a/src/main/java/qna/exceptions/NotFoundException.java
+++ b/src/main/java/qna/exceptions/NotFoundException.java
@@ -1,4 +1,4 @@
-package qna;
+package qna.exceptions;
 
 public class NotFoundException extends RuntimeException {
 }

--- a/src/main/java/qna/exceptions/UnAuthenticationException.java
+++ b/src/main/java/qna/exceptions/UnAuthenticationException.java
@@ -1,4 +1,4 @@
-package qna;
+package qna.exceptions;
 
 public class UnAuthenticationException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/qna/exceptions/UnAuthorizedException.java
+++ b/src/main/java/qna/exceptions/UnAuthorizedException.java
@@ -1,4 +1,4 @@
-package qna;
+package qna.exceptions;
 
 public class UnAuthorizedException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -4,14 +4,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import qna.CannotDeleteException;
-import qna.NotFoundException;
 import qna.domain.*;
+import qna.exceptions.CannotDeleteException;
+import qna.exceptions.NotFoundException;
 
 import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service("qnaService")
 public class QnAService {
@@ -35,24 +32,8 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        DeleteHistories deleteHistories = question.delete(loginUser);
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(deleteHistories.getAll());
     }
 }

--- a/src/test/java/qna/service/AnswerDeleteTest.java
+++ b/src/test/java/qna/service/AnswerDeleteTest.java
@@ -1,0 +1,52 @@
+package qna.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import qna.domain.*;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnswerDeleteTest {
+
+
+    @DisplayName("질문자 삭제 테스트")
+    @Test
+    void deleteAnswer() {
+        Answer answer = AnswerTest.A1;
+        assertThat(answer.isDeleted()).isFalse();
+
+        answer.deleteAnswer();
+        assertThat(answer.isDeleted()).isTrue();
+    }
+
+    @DisplayName("질문자 일급 콜렉션 삭제 테스트")
+    @ParameterizedTest
+    @MethodSource("provideAnswers")
+    void deleteAnswer(Answers answers) {
+        answers.getAnswers()
+                .forEach(answer -> assertThat(answer.isDeleted()).isFalse());
+
+        answers.deleteAll();
+        answers.getAnswers()
+                .forEach(answer -> assertThat(answer.isDeleted()).isTrue());
+    }
+
+    private static Stream<Arguments> provideAnswers() {
+        Answers answers = Answers.from(Arrays.asList(
+                new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1"),
+                new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents2"),
+                new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents3"),
+                new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents4")
+        ));
+        return Stream.of(
+                Arguments.of(answers)
+        );
+    }
+
+}

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import qna.CannotDeleteException;
+import qna.exceptions.CannotDeleteException;
 import qna.domain.*;
 
 import java.time.LocalDateTime;
@@ -82,8 +82,16 @@ public class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+                DeleteHistory.Builder().contentId(question.getId())
+                        .contentType(ContentType.QUESTION)
+                        .deletedBy(question.getWriter())
+                        .createDate(LocalDateTime.now())
+                        .build(),
+                DeleteHistory.Builder().contentId(answer.getId())
+                        .contentType(ContentType.ANSWER)
+                        .deletedBy(answer.getWriter())
+                        .createDate(LocalDateTime.now())
+                        .build());
         verify(deleteHistoryService).saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/service/QuestionDeleteTest.java
+++ b/src/test/java/qna/service/QuestionDeleteTest.java
@@ -1,0 +1,103 @@
+package qna.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import qna.domain.*;
+import qna.exceptions.CannotDeleteException;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class QuestionDeleteTest {
+
+    @DisplayName("질문 삭제 테스트")
+    @ParameterizedTest
+    @MethodSource("provideQuestionAndUser")
+    void deleteQuestionByUser(Question question, User loginUser) throws CannotDeleteException {
+        DeleteHistories histories = question.delete(loginUser);
+        assertThat(question.isDeleted()).isTrue();
+    }
+
+    private static Stream<Arguments> provideQuestionAndUser() {
+        return Stream.of(
+                Arguments.of(QuestionTest.Q1, UserTest.JAVAJIGI),
+                Arguments.of(QuestionTest.Q2, UserTest.SANJIGI)
+        );
+    }
+
+    @DisplayName("다른 작성자의 글을 삭제 테스트")
+    @ParameterizedTest
+    @MethodSource("provideUnMatchQuestionAndUser")
+    void deleteNotMatchedQuestionByUser(Question question, User loginUser) {
+        assertThatThrownBy(() -> question.delete(loginUser))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage(Question.ERROR_DENIED_DELETE_PERMISSION);
+
+    }
+
+    private static Stream<Arguments> provideUnMatchQuestionAndUser() {
+        return Stream.of(
+                Arguments.of(QuestionTest.Q1, UserTest.SANJIGI),
+                Arguments.of(QuestionTest.Q2, UserTest.JAVAJIGI)
+        );
+    }
+
+    @DisplayName("답변이 없는 경우 질문 삭제 테스트")
+    @ParameterizedTest
+    @MethodSource("provideQuestionOfNotExistsAnswer")
+    void deleteNotExistsAnswerQuestion(Question question, User loginUser) throws CannotDeleteException {
+        question.delete(loginUser);
+        assertThat(question.isDeleted()).isTrue();
+    }
+
+    private static Stream<Arguments> provideQuestionOfNotExistsAnswer() {
+        Question question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        return Stream.of(
+                Arguments.of(question, UserTest.JAVAJIGI)
+        );
+    }
+
+    @DisplayName("질문자와 답변자가 다른 경우 테스트")
+    @ParameterizedTest
+    @MethodSource("provideQuestionOfNotMatchedAnswer")
+    void deleteNotMatchedAnswerQuestion(Question question, User loginUser) throws CannotDeleteException {
+        assertThatThrownBy(()-> question.delete(loginUser))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage(Question.ERROR_EXISTS_OTHER_WRITTEN);
+    }
+
+    private static Stream<Arguments> provideQuestionOfNotMatchedAnswer() {
+        Question question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        question.addAnswer(AnswerTest.A2);
+        return Stream.of(
+                Arguments.of(question, UserTest.JAVAJIGI)
+        );
+    }
+
+    @DisplayName("질문 삭제 후 답변 삭제상태 테스트")
+    @ParameterizedTest
+    @MethodSource("provideQuestionWithAnswerAndUser")
+    void deleteQuestionAndAnswer(Question question, User loginUser) throws CannotDeleteException {
+        assertThat(question.isDeleted()).isFalse();
+
+        question.delete(loginUser);
+
+        Answers answers = question.getAnswers();
+        answers.getAnswers()
+                .forEach(answer -> assertThat(answer.isDeleted()).isTrue());
+
+    }
+
+    private static Stream<Arguments> provideQuestionWithAnswerAndUser() {
+        Question question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        question.addAnswer(AnswerTest.A1);
+        return Stream.of(
+                Arguments.of(question, UserTest.JAVAJIGI)
+        );
+    }
+
+}


### PR DESCRIPTION
안녕하세요. 미션4  첫 번째 미션 PR입니다. 😄 
서비스로직에서 맡고 있는 과중한 책임들을 Question과 Answer객체로 이전했으며
DeleteHistories와 Answers 일급콜렉션을 만들었습니다. 

삭제 기록 객체(DeleteHistory)는 빌더패턴을 적용해 인수갯수를 줄였고, Answer와 Question은 각각 삭제로직 수행 후 삭제기록객체를 반환하도록 기능을 구현했습니다. 

테스트는 기능요구사항에서 말하는 조건들 위주로 정상/예외 테스트를 했습니다. 감사합니다. 