### PR TITLE
1단계 - 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/CannotDeleteException.java
+++ b/src/main/java/qna/CannotDeleteException.java
@@ -1,6 +1,6 @@
 package qna;
 
-public class CannotDeleteException extends Exception {
+public class CannotDeleteException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public CannotDeleteException(String message) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -5,7 +5,6 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -22,7 +21,7 @@ public class Answer extends AbstractEntity {
 
     private boolean deleted = false;
 
-    public Answer() {
+    protected Answer() {
     }
 
     public Answer(User writer, Question question, String contents) {
@@ -32,22 +31,17 @@ public class Answer extends AbstractEntity {
     public Answer(Long id, User writer, Question question, String contents) {
         super(id);
 
-        if(writer == null) {
+        if (writer == null) {
             throw new UnAuthorizedException();
         }
 
-        if(question == null) {
+        if (question == null) {
             throw new NotFoundException();
         }
 
         this.writer = writer;
         this.question = question;
         this.contents = contents;
-    }
-
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
     }
 
     public boolean isDeleted() {
@@ -62,10 +56,6 @@ public class Answer extends AbstractEntity {
         return writer;
     }
 
-    public String getContents() {
-        return contents;
-    }
-
     public void toQuestion(Question question) {
         this.question = question;
     }
@@ -76,7 +66,7 @@ public class Answer extends AbstractEntity {
         }
         deleted = true;
 
-        return new DeleteHistory(ContentType.ANSWER, getId(), writer, LocalDateTime.now());
+        return DeleteHistory.of(ContentType.ANSWER, getId(), writer);
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,9 +1,11 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -66,6 +68,15 @@ public class Answer extends AbstractEntity {
 
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public DeleteHistory delete(User loginUser) {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+        deleted = true;
+
+        return new DeleteHistory(ContentType.ANSWER, getId(), writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,31 @@
+package qna.domain;
+
+import org.hibernate.annotations.Where;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+public class Answers {
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Where(clause = "deleted = false")
+    @OrderBy("id ASC")
+    private final List<Answer> answers;
+
+    public Answers() {
+        this.answers = new ArrayList<>();
+    }
+
+    public void add(Answer answer) {
+        this.answers.add(answer);
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -18,12 +18,12 @@ public class Answers {
     @OrderBy("id ASC")
     private final List<Answer> answers;
 
-    public Answers() {
+    protected Answers() {
         this.answers = new ArrayList<>();
     }
 
     public void add(Answer answer) {
-        this.answers.add(answer);
+        answers.add(answer);
     }
 
     public List<DeleteHistory> delete(User loginUser) {

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -8,6 +8,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Embeddable
 public class Answers {
@@ -25,7 +26,10 @@ public class Answers {
         this.answers.add(answer);
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public List<DeleteHistory> delete(User loginUser) {
+        return answers.stream()
+                .filter(user -> user.isOwner(loginUser))
+                .map(answer -> answer.delete(loginUser))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -21,7 +21,7 @@ public class DeleteHistory {
 
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory() {
+    protected DeleteHistory() {
     }
 
     public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
@@ -29,6 +29,10 @@ public class DeleteHistory {
         this.contentId = contentId;
         this.deletedBy = deletedBy;
         this.createDate = createDate;
+    }
+
+    public static DeleteHistory of(ContentType type, Long id, User user) {
+        return new DeleteHistory(type, id, user, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -3,7 +3,6 @@ package qna.domain;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +23,7 @@ public class Question extends AbstractEntity {
 
     private boolean deleted = false;
 
-    public Question() {
+    protected Question() {
     }
 
     public Question(String title, String contents) {
@@ -36,24 +35,6 @@ public class Question extends AbstractEntity {
         super(id);
         this.title = title;
         this.contents = contents;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public Question setTitle(String title) {
-        this.title = title;
-        return this;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public Question setContents(String contents) {
-        this.contents = contents;
-        return this;
     }
 
     public User getWriter() {
@@ -78,18 +59,13 @@ public class Question extends AbstractEntity {
         return deleted;
     }
 
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public List<DeleteHistory> delete(User loginUser) {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
         deleted = true;
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), writer, LocalDateTime.now()));
+        deleteHistories.add(DeleteHistory.of(ContentType.QUESTION, getId(), writer));
         deleteHistories.addAll(answers.delete(loginUser));
 
         return deleteHistories;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import org.hibernate.annotations.Where;
+import qna.CannotDeleteException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,10 +19,8 @@ public class Question extends AbstractEntity {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
-    @Where(clause = "deleted = false")
-    @OrderBy("id ASC")
-    private List<Answer> answers = new ArrayList<>();
+    @Embedded
+    private Answers answers = new Answers();
 
     private boolean deleted = false;
 
@@ -85,7 +84,7 @@ public class Question extends AbstractEntity {
     }
 
     public List<Answer> getAnswers() {
-        return answers;
+        return answers.getAnswers();
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,9 +1,9 @@
 package qna.domain;
 
-import org.hibernate.annotations.Where;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,17 +74,25 @@ public class Question extends AbstractEntity {
         return writer.equals(loginUser);
     }
 
+    public boolean isDeleted() {
+        return deleted;
+    }
+
     public Question setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;
     }
 
-    public boolean isDeleted() {
-        return deleted;
-    }
+    public List<DeleteHistory> delete(User loginUser) {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+        deleted = true;
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), writer, LocalDateTime.now()));
+        deleteHistories.addAll(answers.delete(loginUser));
 
-    public List<Answer> getAnswers() {
-        return answers.getAnswers();
+        return deleteHistories;
     }
 
     @Override

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -35,24 +35,8 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,20 @@
 package qna.domain;
 
-public class AnswerTest {
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+
+    @DisplayName("다른 사람이 쓴 답변이 있으면 삭제 할 수 없다.")
+    @Test
+    void delete_fail() {
+        assertThatThrownBy(() -> A1.delete(UserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,19 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("자신이 쓴 질문이 아니면 삭제 할 수 없다.")
+    @Test
+    void delete_fail() {
+        assertThatThrownBy(() -> Q1.delete(UserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
 }


### PR DESCRIPTION
안녕하세요. 리뷰어님!  
볼링을 한번도 쳐본적이 없어서 이번 미션은 볼링 규칙부터 하나하나 알아야 해서 
어려운 미션이 될 거 같은데... 잘부탁드리겠습니다! 

1단계 미션 진행하면서 몇가지 궁금했던점 질문도 같이 남겨봅니다.
1. 미션을 진행하면서 각 객체에 삭제의 책임을 넘기고 해당 객체의 삭제 기능에 대한 테스트코드를 작성하였는데요. 이 테스트는 QnaServiceTest 와 같은 기능을 테스트하는 것인데 중복해서 있는게 맞을지 한쪽에만 있는게 맞는건지 궁금합니다. QnaServiceTest 가 실제 db 와 연결해서 하는 테스트라면 둘 다 있는게 의미가 있겠지만 Mock 으로 하는 테스트라 둘 다 있어야 하는지 잘모르겠습니다. 
2. Question 클래스에서 answers 를 다음과 같이 사용하고 있습니다. 
`
@Embedded
    private Answers answers = new Answers();
`
JPA 를 사용할 때 Collection 같은 경우는 선언과 동시에 초기화를 하라는 내용을 많이 보았는데요. 
그렇다면 Collection 변수는 선언과 동시에 초기화를 하고 다시 값이 할당될 일이 없다면 final 을 붙여줘도 되는건지 아니면 다른 변수처럼 final 을 안쓰고 일관되게 가는게 좋을지 궁금합니다. 