### PR TITLE
Step1. 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/CannotDeleteException.java
+++ b/src/main/java/qna/CannotDeleteException.java
@@ -1,6 +1,6 @@
 package qna;
 
-public class CannotDeleteException extends Exception {
+public class CannotDeleteException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public CannotDeleteException(String message) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -43,6 +44,13 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
+    public void delete(User loginUser) {
+        if (!this.isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+        setDeleted(true);
+    }
+
     public Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;
@@ -52,7 +60,7 @@ public class Answer extends AbstractEntity {
         return deleted;
     }
 
-    public boolean isOwner(User writer) {
+    private boolean isOwner(User writer) {
         return this.writer.equals(writer);
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -5,6 +5,7 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -74,6 +75,10 @@ public class Answer extends AbstractEntity {
 
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public DeleteHistory createRecord() {
+        return new DeleteHistory(ContentType.ANSWER, this.getId(), this.getWriter(), LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -51,7 +51,7 @@ public class Answer extends AbstractEntity {
         setDeleted(true);
     }
 
-    public Answer setDeleted(boolean deleted) {
+    private Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;
     }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,21 @@
+package qna.domain;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Answers {
+    private final List<Answer> answers;
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public void delete(User loginUser) {
+        answers.stream()
+                .forEach(answer -> answer.delete(loginUser));
+    }
+
+    public List<Answer> getAnswers() {
+        return Collections.unmodifiableList(answers);
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -15,6 +15,11 @@ public class Answers {
                 .forEach(answer -> answer.delete(loginUser));
     }
 
+    public void record(DeleteHistories deleteHistories) {
+        answers.stream()
+                .forEach(answer -> deleteHistories.add(answer.createRecord()));
+    }
+
     public List<Answer> getAnswers() {
         return Collections.unmodifiableList(answers);
     }

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,29 @@
+package qna.domain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DeleteHistories {
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories() {
+        deleteHistories = new ArrayList<>();
+    }
+
+    public void add(DeleteHistory deleteHistory) {
+        deleteHistories.add(deleteHistory);
+    }
+
+    public void add(Question question) {
+        question.record(this);
+    }
+
+    public void add(Answers answers) {
+        answers.record(this);
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return Collections.unmodifiableList(deleteHistories);
+    }
+}

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -84,7 +84,7 @@ public class Question extends AbstractEntity {
         return writer.equals(loginUser);
     }
 
-    public Question setDeleted(boolean deleted) {
+    private Question setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -4,6 +4,7 @@ import org.hibernate.annotations.Where;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -91,6 +92,14 @@ public class Question extends AbstractEntity {
 
     public boolean isDeleted() {
         return deleted;
+    }
+
+    public void record(DeleteHistories deleteHistories) {
+        deleteHistories.add(createRecord());
+    }
+
+    private DeleteHistory createRecord() {
+        return new DeleteHistory(ContentType.QUESTION, this.getId(), this.getWriter(), LocalDateTime.now());
     }
 
     public Answers getAnswers() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -5,6 +5,7 @@ import qna.CannotDeleteException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Entity
@@ -92,8 +93,8 @@ public class Question extends AbstractEntity {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public Answers getAnswers() {
+        return new Answers(Collections.unmodifiableList(answers));
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import org.hibernate.annotations.Where;
+import qna.CannotDeleteException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -71,7 +72,14 @@ public class Question extends AbstractEntity {
         answers.add(answer);
     }
 
-    public boolean isOwner(User loginUser) {
+    public void delete(User loginUser) {
+        if (!this.isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+        setDeleted(true);
+    }
+
+    private boolean isOwner(User loginUser) {
         return writer.equals(loginUser);
     }
 

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -35,9 +35,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        question.delete(loginUser);
 
         List<Answer> answers = question.getAnswers();
         for (Answer answer : answers) {

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -40,11 +40,10 @@ public class QnAService {
         Answers answers = question.getAnswers();
         answers.delete(loginUser);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers.getAnswers()) {
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        DeleteHistories deleteHistories = new DeleteHistories();
+        deleteHistories.add(question);
+        deleteHistories.add(answers);
+
+        deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -39,9 +39,7 @@ public class QnAService {
 
         List<Answer> answers = question.getAnswers();
         for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
+            answer.delete(loginUser);
         }
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -37,15 +37,13 @@ public class QnAService {
         Question question = findQuestionById(questionId);
         question.delete(loginUser);
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            answer.delete(loginUser);
-        }
+        Answers answers = question.getAnswers();
+        answers.delete(loginUser);
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
+        // question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
+        for (Answer answer : answers.getAnswers()) {
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -41,10 +41,8 @@ public class QnAService {
         answers.delete(loginUser);
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        // question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers.getAnswers()) {
-            answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,23 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @Test
+    void 다른_사람의_답변_삭제() {
+        assertThatThrownBy(() -> {
+            A1.delete(A2.getWriter());
+        }).isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    void 본인의_답변_삭제() {
+        A1.delete(A1.getWriter());
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,23 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Test
+    void 다른_사람의_질문_삭제() {
+        assertThatThrownBy(() -> {
+            Q1.delete(Q2.getWriter());
+        }).isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    void 자신의_질문_삭제() {
+        Q1.delete(Q1.getWriter());
+    }
 }


### PR DESCRIPTION
안녕하세요 리뷰어님
3단계가 아직 다 끝나진 않았는데... 함께 진행하고 싶어 PR 요청 드립니다.
힌트를 오래 생각했는데 좀 어렵게 느껴져서... 피드백 주시면 다시 반영하도록 하겠습니다.😅

`QnAService`의 로직을 각 도메인(`Question`, `Answer`, `DeleteHistory`)으로 이동시키고,
그에 맞는 단위 테스트를 작성해야겠다고 생각했는데요.
모든 public 메소드를 테스트하지 못하고, `DeleteHistories` 객체의 경우 테스트 시도하다가 결국 실패하였습니다.

미리 감사드립니다.
좋은 하루 되세요!🙇

- - -
이하에 남기는 글은 질문은 아니고... 제가 남겨 놓고 나중에 공부해보려고 기록해 놓은 부분입니다!😅

* `@Transactional` 안에 `@Transactional`을 써도 되나?
* `Question` 클래스의 작성자 필드는 왜 생성자로 생성해주지 않고 `writeBy` 메소드를 사용하지?
* `CannotDeleteException` 클래스는 왜 `RuntimeException`이 아니었지?
* `DeleteHistories` 및 `Answers`에 대한 테스트를 하지 못했다