### PR TITLE
[볼링 점수판 - OOP] 1단계 - 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,9 +1,15 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Lob;
+
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -41,6 +47,21 @@ public class Answer extends AbstractEntity {
         this.writer = writer;
         this.question = question;
         this.contents = contents;
+    }
+
+    public void delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+
+        this.deleted = true;
+    }
+
+    public DeleteHistory getDeleteHistory() {
+        if (isDeleted()) {
+            return DeleteHistory.create(this);
+        }
+        return null;
     }
 
     public Answer setDeleted(boolean deleted) {

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,43 @@
+package qna.domain;
+
+import org.hibernate.annotations.Where;
+import qna.CannotDeleteException;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Embeddable
+public class Answers {
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Where(clause = "deleted = false")
+    @OrderBy("id ASC")
+    private List<Answer> answers = new ArrayList<>();
+
+    public Answers() {
+    }
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    void delete(User loginUser) throws CannotDeleteException {
+        for (Answer answer : answers) {
+            answer.delete(loginUser);
+        }
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return answers.stream()
+                .filter(answer -> answer.getDeleteHistory() != null)
+                .map(Answer::getDeleteHistory).collect(Collectors.toList());
+    }
+
+    public void add(Answer answer) {
+        answers.add(answer);
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -31,6 +31,14 @@ public class DeleteHistory {
         this.createDate = createDate;
     }
 
+    public static DeleteHistory create(Question question) {
+        return new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now());
+    }
+
+    public static DeleteHistory create(Answer answer) {
+        return new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -35,24 +35,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        question.delete(loginUser);
+        deleteHistoryService.saveAll(question.getDeleteHistories());
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,30 @@
 package qna.domain;
 
-public class AnswerTest {
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AnswerTest {
+    public static final Answer JAVAJIGI_ANSWER = new Answer(UserTest.JAVAJIGI, QuestionTest.JAVAJIGI_QUESTION, "Answers Contents1");
+    public static final Answer SANJIGI_ANSWER = new Answer(UserTest.SANJIGI, QuestionTest.JAVAJIGI_QUESTION, "Answers Contents2");
+    public static final Answer WU22E_ANSWER = new Answer(UserTest.WU22E, QuestionTest.JAVAJIGI_QUESTION, "Answers Contents3");
+
+    @Test
+    void delete_답변_작성자는_자신의_답변을_삭제할_수_있다() throws CannotDeleteException {
+        JAVAJIGI_ANSWER.delete(UserTest.JAVAJIGI);
+        assertThat(JAVAJIGI_ANSWER.isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete_다른_사람의_답변을_삭제할_수_없다() {
+        assertThatThrownBy(() -> JAVAJIGI_ANSWER.delete(UserTest.SANJIGI)).isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    void getDeleteHistory_삭제된_답변_이력을_가져온다() throws CannotDeleteException {
+        JAVAJIGI_ANSWER.delete(UserTest.JAVAJIGI);
+        assertThat(JAVAJIGI_ANSWER.getDeleteHistory()).isEqualTo(DeleteHistory.create(JAVAJIGI_ANSWER));
+    }
 }

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,21 @@
+package qna.domain;
+
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static qna.domain.AnswerTest.JAVAJIGI_ANSWER;
+import static qna.domain.AnswerTest.SANJIGI_ANSWER;
+import static qna.domain.AnswerTest.WU22E_ANSWER;
+
+class AnswersTest {
+    @Test
+    void getDeleteHistories_삭제된_답변_이력들을_가져온다() throws CannotDeleteException {
+        JAVAJIGI_ANSWER.delete(UserTest.JAVAJIGI);
+        SANJIGI_ANSWER.delete(UserTest.SANJIGI);
+        Answers answers = new Answers(List.of(JAVAJIGI_ANSWER, SANJIGI_ANSWER, WU22E_ANSWER));
+        assertThat(answers.getDeleteHistories()).isEqualTo(List.of(DeleteHistory.create(JAVAJIGI_ANSWER), DeleteHistory.create(SANJIGI_ANSWER)));
+    }
+}

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,17 @@
+package qna.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeleteHistoryTest {
+    @Test
+    void create_질문_삭제_이력_생성() {
+        assertThat(DeleteHistory.create(AnswerTest.JAVAJIGI_ANSWER)).isNotNull().isInstanceOf(DeleteHistory.class);
+    }
+
+    @Test
+    void create_답변_삭제_이력_생성() {
+        assertThat(DeleteHistory.create(QuestionTest.JAVAJIGI_QUESTION)).isNotNull().isInstanceOf(DeleteHistory.class);
+    }
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -6,7 +6,7 @@ import qna.CannotDeleteException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class QuestionTest {
+public class QuestionTest {
     public static final Question JAVAJIGI_QUESTION = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question SANJIGI_QUESTION = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,23 @@
 package qna.domain;
 
-public class QuestionTest {
-    public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
-    public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class QuestionTest {
+    public static final Question JAVAJIGI_QUESTION = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
+    public static final Question SANJIGI_QUESTION = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Test
+    void delete_질문_작성자는_자신의_질문을_삭제할_수_있다() throws CannotDeleteException {
+        JAVAJIGI_QUESTION.delete(UserTest.JAVAJIGI);
+        assertThat(JAVAJIGI_QUESTION.isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete_다른_사람의_질문을_삭제할_수_없다() {
+        assertThatThrownBy(() -> JAVAJIGI_QUESTION.delete(UserTest.SANJIGI)).isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -3,4 +3,5 @@ package qna.domain;
 public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+    public static final User WU22E = new User(3L, "wu22e", "password", "name", "wu22e@slipp.net");
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -36,7 +36,7 @@ public class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
-        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.JAVAJIGI_QUESTION, "Answers Contents1");
         question.addAnswer(answer);
     }
 


### PR DESCRIPTION
안녕하세요! 볼링 점수판 미션을 진행하게된 김형우 라고 합니다!

질문 삭제하기 기능 리팩토링 하면서 고민한 부분은 
question을 delete 할 때 바로 삭제 이력에 대한 내용을 반환해주는것이 맞는가? 에 대한 고민이 있었습니다.
read를 할 메서드와 delete할 메서드를 나누는게 맞다고 판단하여 해당 내용을 분리하여 구현해 보았습니다.
리뷰어님 생각은 어떤지 궁금합니다!

나머지 부분에 대한 리뷰 또한 잘 부탁드립니다!

