### PR TITLE
Step1. 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,9 +1,16 @@
 package qna.domain;
 
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
-
-import javax.persistence.*;
 
 @Entity
 public class Answer extends AbstractEntity {
@@ -47,6 +54,14 @@ public class Answer extends AbstractEntity {
         this.writer = writer;
     }
 
+    public DeleteHistory delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+        deleted = true;
+        return new DeleteHistory(ContentType.ANSWER, getId(), writer, LocalDateTime.now());
+    }
+    
     public Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -43,6 +43,10 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
+    public Answer(User writer) {
+        this.writer = writer;
+    }
+
     public Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -50,10 +50,6 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
-    public Answer(User writer) {
-        this.writer = writer;
-    }
-
     public DeleteHistory delete(User loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
@@ -62,11 +58,6 @@ public class Answer extends AbstractEntity {
         return new DeleteHistory(ContentType.ANSWER, getId(), writer, LocalDateTime.now());
     }
     
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,11 +15,7 @@ public class Answers {
     public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+            deleteHistories.add(answer.delete(loginUser));
         }
         return deleteHistories;
     }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,27 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import qna.CannotDeleteException;
+
+public class Answers {
+    private final List<Answer> answers;
+
+    public Answers(final List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+            answer.setDeleted(true);
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        }
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -16,8 +16,6 @@ import javax.persistence.OrderBy;
 
 import org.hibernate.annotations.Where;
 
-import com.sun.istack.NotNull;
-
 import qna.CannotDeleteException;
 
 @Entity
@@ -98,21 +96,12 @@ public class Question extends AbstractEntity {
         return deleted;
     }
 
-    public Answers getAnswers() {
-        return new Answers(answers);
-    }
-
     public List<DeleteHistory> delete(final User loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
         deleted = true;
         return deleteHistories(loginUser);
-    }
-
-    public Question addAnswers(@NotNull final List<Answer> answers) {
-        this.answers = answers;
-        return this;
     }
     
     private List<DeleteHistory> deleteHistories(final User loginUser) throws CannotDeleteException {
@@ -122,17 +111,6 @@ public class Question extends AbstractEntity {
         return deleteHistories;
     }
 
-    public Question clone(long id) {
-        Question question = new Question();
-        question.setId(id);
-        question.writer = writer;
-        question.title = title;
-        question.contents = contents;
-        question.answers = answers;
-        question.deleted = deleted;
-        return question;
-    }
-    
     @Override
     public String toString() {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,10 +1,24 @@
 package qna.domain;
 
-import org.hibernate.annotations.Where;
-
-import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+
+import org.hibernate.annotations.Where;
+
+import com.sun.istack.NotNull;
+
+import qna.CannotDeleteException;
 
 @Entity
 public class Question extends AbstractEntity {
@@ -84,10 +98,41 @@ public class Question extends AbstractEntity {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public Answers getAnswers() {
+        return new Answers(answers);
     }
 
+    public List<DeleteHistory> delete(final User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+        deleted = true;
+        return deleteHistories(loginUser);
+    }
+
+    public Question addAnswers(@NotNull final List<Answer> answers) {
+        this.answers = answers;
+        return this;
+    }
+    
+    private List<DeleteHistory> deleteHistories(final User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), writer, LocalDateTime.now()));
+        deleteHistories.addAll(new Answers(answers).delete(loginUser));
+        return deleteHistories;
+    }
+
+    public Question clone(long id) {
+        Question question = new Question();
+        question.setId(id);
+        question.writer = writer;
+        question.title = title;
+        question.contents = contents;
+        question.answers = answers;
+        question.deleted = deleted;
+        return question;
+    }
+    
     @Override
     public String toString() {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -87,11 +87,6 @@ public class Question extends AbstractEntity {
         return writer.equals(loginUser);
     }
 
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -1,17 +1,18 @@
 package qna.service;
 
+import javax.annotation.Resource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.*;
-
-import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import qna.domain.AnswerRepository;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
 
 @Service("qnaService")
 public class QnAService {
@@ -34,25 +35,6 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
-        Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(findQuestionById(questionId).delete(loginUser));
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,0 @@
-package qna.domain;
-
-public class AnswerTest {
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
-}

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,0 +1,35 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.*;
+import static qna.domain.AnswersTest.*;
+import static qna.domain.UserTest.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import qna.CannotDeleteException;
+
+class AnswerTest {
+    @DisplayName("답변 소유자와 로그인 한 사용자가 동일하면 답변을 삭제할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(longs = { 123, 45678, 9 })
+    void delete(long contentId) throws CannotDeleteException {
+        Answer answer = answer(contentId, JAVAJIGI, JAVAJIGI);
+        assertThat(answer.delete(JAVAJIGI)).isEqualTo(new DeleteHistory(ContentType.ANSWER, contentId, JAVAJIGI, LocalDateTime.now()));
+        assertThat(answer.isDeleted()).isTrue();
+    }
+
+    @DisplayName("답변 소유자와 로그인 한 사용자가 다르다면 답변을 삭제할 수 없다.")
+    @Test
+    void delete_when_invalid_user() {
+        long contentId = 456L;
+        Answer answer = answer(contentId, JAVAJIGI, JAVAJIGI);
+        assertThatThrownBy(() -> answer.delete(SANJIGI)).isInstanceOf(CannotDeleteException.class)
+                                                        .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        assertThat(answer.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import qna.CannotDeleteException;
 
 class AnswersTest {
-    public static final List<Answer> SAME_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.JAVAJIGI));
-    public static final List<Answer> DIFFERENT_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.SANJIGI));
+    public static final List<Answer> SAME_OWNER = List.of(answer(UserTest.JAVAJIGI, UserTest.JAVAJIGI), answer(UserTest.JAVAJIGI, UserTest.JAVAJIGI));
+    public static final List<Answer> DIFFERENT_OWNER = List.of(answer(UserTest.JAVAJIGI, UserTest.JAVAJIGI), answer(UserTest.JAVAJIGI, UserTest.SANJIGI));
     
     @DisplayName("답변 소유자 외에 다른 사람이 작성한 답변이 없다면 답변 삭제상태를 true 로 바꾸고 삭제 히스토리를 리턴한다.")
     @Test
@@ -31,5 +31,13 @@ class AnswersTest {
         assertThatThrownBy(() -> new Answers(DIFFERENT_OWNER).delete(UserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class)
                 .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+
+    public static Answer answer(long contentId, User questionWriter, User answerWriter) {
+        return new Answer(contentId, answerWriter, QuestionTest.question(123L, questionWriter), "contents");
+    }
+    
+    public static Answer answer(User questionWriter, User answerWriter) {
+        return new Answer(answerWriter, QuestionTest.question(123L, questionWriter), "contents");
     }
 }

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,49 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import qna.CannotDeleteException;
+
+class AnswersTest {
+    @DisplayName("답변 소유자 외에 다른 사람이 작성한 답변이 없다면 답변 삭제상태를 true 로 바꾸고 삭제 히스토리를 리턴한다.")
+    @Test
+    void delete() throws CannotDeleteException {
+        User owner = user(123L);
+        List<Answer> answers = List.of(new Answer(owner), new Answer(owner));
+        
+        assertThat(new Answers(answers).delete(owner))
+                .containsExactlyElementsOf(List.of(
+                        new DeleteHistory(ContentType.ANSWER, answers.get(0).getId(), answers.get(0).getWriter(), LocalDateTime.now()),
+                        new DeleteHistory(ContentType.ANSWER, answers.get(1).getId(), answers.get(1).getWriter(), LocalDateTime.now())
+                ));
+        assertThat(answers).allSatisfy((Answer answer) -> answer.isDeleted());
+    }
+
+    @DisplayName("답변 소유자외에 다른 사람이 작성한 답변이 있다면 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_owner() {
+        User owner = user(123L);
+        User other = user(321L);
+
+        assertThatThrownBy(() -> new Answers(List.of(new Answer(owner), new Answer(other))).delete(other))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+    
+    private User user(long id) {
+        return new User(id, "userId", "password", "name", "email");
+    }
+
+    /*private void verifyDeleteHistories(Question question, Answer answer) {
+        List<DeleteHistory> deleteHistories = Arrays.asList(
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        verify(deleteHistoryService).saveAll(deleteHistories);
+    }*/
+}

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -11,39 +11,25 @@ import org.junit.jupiter.api.Test;
 import qna.CannotDeleteException;
 
 class AnswersTest {
+    public static final List<Answer> SAME_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.JAVAJIGI));
+    public static final List<Answer> DIFFERENT_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.SANJIGI));
+    
     @DisplayName("답변 소유자 외에 다른 사람이 작성한 답변이 없다면 답변 삭제상태를 true 로 바꾸고 삭제 히스토리를 리턴한다.")
     @Test
     void delete() throws CannotDeleteException {
-        User owner = user(123L);
-        List<Answer> answers = List.of(new Answer(owner), new Answer(owner));
-        
-        assertThat(new Answers(answers).delete(owner))
+        assertThat(new Answers(SAME_OWNER).delete(UserTest.JAVAJIGI))
                 .containsExactlyElementsOf(List.of(
-                        new DeleteHistory(ContentType.ANSWER, answers.get(0).getId(), answers.get(0).getWriter(), LocalDateTime.now()),
-                        new DeleteHistory(ContentType.ANSWER, answers.get(1).getId(), answers.get(1).getWriter(), LocalDateTime.now())
+                        new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(0).getId(), SAME_OWNER.get(0).getWriter(), LocalDateTime.now()),
+                        new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(1).getId(), SAME_OWNER.get(1).getWriter(), LocalDateTime.now())
                 ));
-        assertThat(answers).allSatisfy((Answer answer) -> answer.isDeleted());
+        assertThat(SAME_OWNER).allSatisfy((Answer answer) -> answer.isDeleted());
     }
 
     @DisplayName("답변 소유자외에 다른 사람이 작성한 답변이 있다면 예외를 발생시킨다.")
     @Test
     void delete_when_invalid_owner() {
-        User owner = user(123L);
-        User other = user(321L);
-
-        assertThatThrownBy(() -> new Answers(List.of(new Answer(owner), new Answer(other))).delete(other))
+        assertThatThrownBy(() -> new Answers(DIFFERENT_OWNER).delete(UserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class)
                 .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
     }
-    
-    private User user(long id) {
-        return new User(id, "userId", "password", "name", "email");
-    }
-
-    /*private void verifyDeleteHistories(Question question, Answer answer) {
-        List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        verify(deleteHistoryService).saveAll(deleteHistories);
-    }*/
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -42,22 +42,22 @@ public class QuestionTest {
         Question question = question(123L, UserTest.JAVAJIGI, UserTest.JAVAJIGI, UserTest.JAVAJIGI);
         assertThatThrownBy(() -> question.delete(UserTest.SANJIGI)).isInstanceOf(CannotDeleteException.class).hasMessage("질문을 삭제할 권한이 없습니다.");
     }
-    
-    public static Question question(long contentId, User questionWriter, User... answerWriters) {
-        Question question = question(contentId, questionWriter);
-        for (Answer answer : answers(answerWriters)) {
-            question.addAnswer(answer);
-        }
-        return question;
-    }
-    
-    private static Question question(long contentId, User writer) {
+
+    public static Question question(long contentId, User writer) {
         Question question = new Question("title", "contents").writeBy(writer);
         question.setId(contentId);
         return question;
     }
+
+    private static List<Answer> answers(User questionWriter, User... answerWriters) {
+        return Arrays.stream(answerWriters).map(writer -> answer(questionWriter, writer)).collect(Collectors.toList());
+    }
     
-    private static List<Answer> answers(User... writers) {
-        return Arrays.stream(writers).map(writer -> new Answer(writer)).collect(Collectors.toList());
+    private static Question question(long contentId, User questionWriter, User... answerWriters) {
+        Question question = question(contentId, questionWriter);
+        for (Answer answer : answers(questionWriter, answerWriters)) {
+            question.addAnswer(answer);
+        }
+        return question;
     }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,45 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.*;
+import static qna.domain.AnswersTest.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import qna.CannotDeleteException;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("질문 소유자와 로그인 한 사용자가 같고, 답변 소유자 외에 다른 사용자가 작성한 답변이 없다면 질문 삭제상태를 true 로 바꾸고 삭제 이력을 리턴한다.")
+    @Test
+    void delete() throws CannotDeleteException {
+        long id = 123L;
+        Question question = Q1.clone(id).addAnswers(SAME_OWNER);
+        List<DeleteHistory> histories = question.delete(UserTest.JAVAJIGI);
+        
+        assertThat(question.isDeleted()).isTrue();
+        assertThat(histories).hasSameElementsAs(List.of(
+                new DeleteHistory(ContentType.QUESTION, id, UserTest.JAVAJIGI, LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(0).getId(), SAME_OWNER.get(0).getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(1).getId(), SAME_OWNER.get(1).getWriter(), LocalDateTime.now())
+        ));
+    }
+
+    @DisplayName("답변 소유자 외에 다른 사용자가 작성한 답변이 있다면 CannotDeleteException 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_answer_owner() {
+        Question question = Q1.clone(123L).addAnswers(DIFFERENT_OWNER);
+        assertThatThrownBy(() -> question.delete(UserTest.JAVAJIGI)).isInstanceOf(CannotDeleteException.class).hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("질문 소유자와 로그인 한 사용자가 다르다면 CannotDeleteException 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_question_owner() {
+        assertThatThrownBy(() -> Q1.delete(Q2.getWriter())).isInstanceOf(CannotDeleteException.class).hasMessage("질문을 삭제할 권한이 없습니다.");
+    }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -42,7 +42,7 @@ public class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
-        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.question(123L, UserTest.JAVAJIGI, UserTest.JAVAJIGI, UserTest.JAVAJIGI), "Answers Contents1");
+        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.question(123L, UserTest.JAVAJIGI), "Answers Contents1");
         question.addAnswer(answer);
     }
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -1,6 +1,7 @@
 package qna.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,8 +41,9 @@ public class QnaServiceTest {
         question.addAnswer(answer);
     }
 
+    @DisplayName("로그인 한 사용자와 질문한 사람이 같고 질문한 사람 외에 다른 사람의 답변이 없다면 질문의 삭제상태를 true 로 변경하고 삭제이력을 저장한다.")
     @Test
-    public void delete_성공() throws Exception {
+    public void deleteQuestion() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -1,5 +1,13 @@
 package qna.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,18 +15,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import qna.CannotDeleteException;
-import qna.domain.*;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import qna.domain.Answer;
+import qna.domain.ContentType;
+import qna.domain.DeleteHistory;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.QuestionTest;
+import qna.domain.UserTest;
 
 @ExtendWith(MockitoExtension.class)
 public class QnaServiceTest {
@@ -37,7 +42,7 @@ public class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
-        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.question(123L, UserTest.JAVAJIGI, UserTest.JAVAJIGI, UserTest.JAVAJIGI), "Answers Contents1");
         question.addAnswer(answer);
     }
 


### PR DESCRIPTION
* 추가
- `Answers` 클래스를 생성하여 해당 객체를 통해 답변목록을 삭제하는 역할과 책임을 부여하였습니다.

* 변경
- `Question` 객체에게 질문과 답변 삭제하는 역할과 책임을 부여하였습니다.
- `QnaService` 에서는 질문과 답변 삭제를 직접 하지 않고 Question 객체에게 위임하고, 삭제 이력만 비즈니스 레이어 객체에게 위임합니다.

* 참고사항
- 기존에 `Question` 객체와 `Answer` 객체는 양방향 의존성 문제가 있는데 이 부분은 추후 리팩토링 하겠습니다.
- 제가 정의한 삭제는 삭제 = 삭제상태변경(deleted=true) + 삭제이력 생성 입니다.