### PR TITLE
refactor: 1단계 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,24 @@
+package qna.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeleteHistories {
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories() {
+        deleteHistories = new ArrayList<>();
+    }
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public void add(DeleteHistory deleteHistory) {
+        deleteHistories.add(deleteHistory);
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/service/AnswerService.java
+++ b/src/main/java/qna/service/AnswerService.java
@@ -1,0 +1,32 @@
+package qna.service;
+
+import qna.CannotDeleteException;
+import qna.domain.Answer;
+import qna.domain.AnswerRepository;
+import qna.domain.User;
+
+import java.util.List;
+
+
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+
+    public AnswerService(AnswerRepository answerRepository) {
+        this.answerRepository = answerRepository;
+    }
+
+    public List<Answer> deleteAll(List<Answer> answers, User loginUser) throws CannotDeleteException {
+        for (Answer answer : answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+        }
+
+        for (Answer answer : answers) {
+            answer.setDeleted(true);
+        }
+
+        return answerRepository.saveAll(answers);
+    }
+}

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -10,7 +10,6 @@ import qna.domain.*;
 
 import javax.annotation.Resource;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service("qnaService")
@@ -26,6 +25,12 @@ public class QnAService {
     @Resource(name = "deleteHistoryService")
     private DeleteHistoryService deleteHistoryService;
 
+    @Resource(name = "questionService")
+    private QuestionService questionService;
+
+    @Resource(name = "answerService")
+    private AnswerService answerService;
+
     @Transactional(readOnly = true)
     public Question findQuestionById(Long id) {
         return questionRepository.findByIdAndDeletedFalse(id)
@@ -34,25 +39,20 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
+        DeleteHistories deleteHistories = new DeleteHistories();
+
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        questionService.delete(question, loginUser);
+
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
 
         List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+        answerService.deleteAll(answers, loginUser);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
-            answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
-        deleteHistoryService.saveAll(deleteHistories);
+
+        deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/main/java/qna/service/QuestionService.java
+++ b/src/main/java/qna/service/QuestionService.java
@@ -1,0 +1,25 @@
+package qna.service;
+
+import qna.CannotDeleteException;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
+
+
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    public QuestionService(QuestionRepository questionRepository) {
+        this.questionRepository = questionRepository;
+    }
+
+    public Question delete(Question question, User loginUser) throws CannotDeleteException {
+        if (!question.isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        question.setDeleted(true);
+        return questionRepository.save(question);
+    }
+}

--- a/src/test/java/qna/service/AnswerServiceTest.java
+++ b/src/test/java/qna/service/AnswerServiceTest.java
@@ -1,0 +1,58 @@
+package qna.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import qna.CannotDeleteException;
+import qna.domain.Answer;
+import qna.domain.AnswerRepository;
+import qna.domain.QuestionTest;
+import qna.domain.UserTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AnswerServiceTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    private AnswerService answerService;
+
+    private Answer firstAnswer;
+    private Answer deletedFirstAnswer;
+    private Answer secondAnswer;
+
+    @BeforeEach
+    public void setup() {
+        answerService = new AnswerService(answerRepository);
+        firstAnswer = new Answer(1L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        deletedFirstAnswer = new Answer(1L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        deletedFirstAnswer.setDeleted(true);
+        secondAnswer = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    }
+
+
+    @Test
+    @Order(1)
+    public void 답변삭제_성공() throws CannotDeleteException {
+        when(answerRepository.saveAll(List.of(firstAnswer))).thenReturn(List.of(firstAnswer));
+        assertThat(answerService.deleteAll(List.of(firstAnswer), UserTest.JAVAJIGI)).contains(deletedFirstAnswer);
+    }
+
+    @Test
+    @Order(1)
+    public void 답변삭제_실패_다른사람이쓴답변존재() {
+        assertThatThrownBy(
+                () -> answerService.deleteAll(List.of(secondAnswer), UserTest.JAVAJIGI)
+        ).isInstanceOf(CannotDeleteException.class)
+                .hasMessageContaining("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+}

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,63 +26,65 @@ public class QnaServiceTest {
     @Mock
     private DeleteHistoryService deleteHistoryService;
 
+    @Mock
+    private QuestionService questionService;
+
+    @Mock
+    private AnswerService answerService;
+
     @InjectMocks
     private QnAService qnAService;
 
     private Question question;
+    private Question deletedQuestion;
     private Answer answer;
+    private Answer deletedAnswer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        deletedQuestion = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        deletedQuestion.setDeleted(true);
         answer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        deletedAnswer = new Answer(11L, UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        deletedAnswer.setDeleted(true);
         question.addAnswer(answer);
+        deletedQuestion.addAnswer(deletedAnswer);
     }
 
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
-        assertThat(question.isDeleted()).isFalse();
         qnAService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
-        assertThat(question.isDeleted()).isTrue();
         verifyDeleteHistories();
     }
 
     @Test
     public void delete_다른_사람이_쓴_글() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(questionService.delete(question, UserTest.SANJIGI)).thenThrow(new CannotDeleteException("질문을 삭제할 권한이 없습니다."));
 
-        assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(UserTest.SANJIGI, question.getId());
-        }).isInstanceOf(CannotDeleteException.class);
-    }
-
-    @Test
-    public void delete_성공_질문자_답변자_같음() throws Exception {
-        when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-
-        qnAService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
-
-        assertThat(question.isDeleted()).isTrue();
-        assertThat(answer.isDeleted()).isTrue();
-        verifyDeleteHistories();
+        assertThatThrownBy(() ->
+                qnAService.deleteQuestion(UserTest.SANJIGI, question.getId())).isInstanceOf(CannotDeleteException.class);
     }
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(answerService.deleteAll(List.of(answer), UserTest.SANJIGI)).thenThrow(new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다."));
 
-        assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(UserTest.SANJIGI, question.getId());
-        }).isInstanceOf(CannotDeleteException.class);
+        assertThatThrownBy(() ->
+                qnAService.deleteQuestion(UserTest.SANJIGI, question.getId())).isInstanceOf(CannotDeleteException.class);
     }
 
     private void verifyDeleteHistories() {
-        List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        verify(deleteHistoryService).saveAll(deleteHistories);
+        DeleteHistories deleteHistories = new DeleteHistories(
+                Arrays.asList(
+                        new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                        new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())));
+
+        verify(deleteHistoryService).saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/test/java/qna/service/QuestionServiceTest.java
+++ b/src/test/java/qna/service/QuestionServiceTest.java
@@ -1,0 +1,52 @@
+package qna.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import qna.CannotDeleteException;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.UserTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestionServiceTest {
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    private QuestionService questionService;
+
+    private Question question;
+    private Question deletedQuestion;
+
+    @BeforeEach
+    public void setup() {
+        questionService = new QuestionService(questionRepository);
+        question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        deletedQuestion = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        deletedQuestion.setDeleted(true);
+    }
+
+    @Test
+    @Order(1)
+    public void 질문삭제_성공() throws CannotDeleteException {
+        when(questionRepository.save(question)).thenReturn(deletedQuestion);
+        assertThat(questionService.delete(question, UserTest.JAVAJIGI)).isEqualTo(deletedQuestion);
+    }
+
+    @Test
+    @Order(2)
+    public void 질문삭제_실패_질문삭제권한없음() {
+        assertThatThrownBy(
+                () -> questionService.delete(question, UserTest.SANJIGI)
+        ).isInstanceOf(CannotDeleteException.class)
+                .hasMessageContaining("질문을 삭제할 권한이 없습니다.");
+    }
+}


### PR DESCRIPTION
# 요구사항
- 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
- 로그인 사용자와 질문한 사람이 같은 경우 삭제 가능하다.
- 답변이 없는 경우 삭제가 가능하다.
- 질문자와 답변글의 모든 답변자가 같은 경우 삭제가 가능하다.
- 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경한다.
- 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.
- 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.

# 프로그래밍 요구사항
- qna.service.QnaService의 deleteQuestion()는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메소드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
- 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드를 분리해 단위 테스트 가능한 코드 에 대해 단위 테스트를 구현한다.